### PR TITLE
Bump MAX_BPI to 128, to make jazz players happy

### DIFF
--- a/ninjam/server/usercon.h
+++ b/ninjam/server/usercon.h
@@ -54,7 +54,7 @@
 #define PRIV_VOTE 128
 
 #define MAX_BPM 400
-#define MAX_BPI 64
+#define MAX_BPI 128
 #define MIN_BPM 40
 #define MIN_BPI 2
 


### PR DESCRIPTION
I was in the proces of creating some predefined Ninjam sessions and testing the outcome. I was surprised to see that even though I've set `DefaultBPI` to 128, the loop was still 16 bars long. I wanted to have two sessions tweaked for jazz standards, which are in most cases 32 bars long, and while I can still do `/bpi 128` and it will work, I thought it would be nicer to do it from the config file.